### PR TITLE
Bump provider v0.0.1-rc10

### DIFF
--- a/common.ts
+++ b/common.ts
@@ -1,12 +1,12 @@
 import { ethers } from "ethers";
 import {
   PolyjuiceWallet,
-  PolyjuiceConfig,
   PolyjuiceJsonRpcProvider,
 } from "@polyjuice-provider/ethers";
+import { PolyjuiceConfig } from "@polyjuice-provider/base";
 import dotenv from "dotenv";
 import axios from "axios";
-import { AbiItems } from "@polyjuice-provider/base/lib/abi";
+import { AbiItems } from "@polyjuice-provider/base";
 import path from "path";
 import { HexString, Script, utils } from "@ckb-lumos/base";
 
@@ -100,7 +100,7 @@ export function ethEoaAddressToGodwokenShortAddress(
   }
 
   const layer2Lock: Script = {
-    code_hash: polyjuiceConfig.ethAccountLockCodeHash,
+    code_hash: polyjuiceConfig.ethAccountLockCodeHash!,
     hash_type: "type",
     args: polyjuiceConfig.rollupTypeHash + ethAddress.slice(2).toLowerCase(),
   };

--- a/package.json
+++ b/package.json
@@ -33,6 +33,6 @@
   },
   "dependencies": {
     "@ckb-lumos/base": "^0.16.0",
-    "@polyjuice-provider/ethers": "^0.0.1-rc7"
+    "@polyjuice-provider/ethers": "^0.0.1-rc10"
   }
 }

--- a/scripts/multi-sign-wallet.ts
+++ b/scripts/multi-sign-wallet.ts
@@ -11,7 +11,7 @@ import {
   PopulatedTransaction,
   Wallet as EthersWallet,
 } from "ethers";
-import { AbiItems } from "@polyjuice-provider/base/lib/abi";
+import { AbiItems, ShortAddress } from "@polyjuice-provider/base";
 import {
   PolyjuiceJsonRpcProvider,
   PolyjuiceWallet,
@@ -115,8 +115,9 @@ async function main() {
   let deployerRecipientAddress = deployerAddress;
   if (isGodwoken) {
     const { godwoker } = rpc as PolyjuiceJsonRpcProvider;
-    deployerRecipientAddress =
+    const shortAddr: ShortAddress =
       await godwoker.getShortAddressByAllTypeEthAddress(deployerAddress);
+    deployerRecipientAddress = shortAddr.value;
     console.log("Deployer godwoken address:", deployerRecipientAddress);
   }
 

--- a/scripts/stable-swap-3-pool.ts
+++ b/scripts/stable-swap-3-pool.ts
@@ -26,6 +26,7 @@ import MintableToken from "../artifacts/contracts/MintableToken.sol/MintableToke
 import Faucet from "../artifacts/contracts/Faucet.sol/Faucet.json";
 import CurveTokenV3 from "../generated-artifacts/contracts/CurveTokenV3.json";
 import StableSwap3Pool from "../generated-artifacts/contracts/StableSwap3Pool.json";
+import { ShortAddress } from "@polyjuice-provider/base";
 
 type TCallStatic = Contract["callStatic"];
 type TransactionResponse = providers.TransactionResponse;
@@ -123,8 +124,9 @@ async function main() {
   let deployerRecipientAddress = deployerAddress;
   if (isGodwoken) {
     const { godwoker } = rpc as PolyjuiceJsonRpcProvider;
-    deployerRecipientAddress =
+    const shortAddress: ShortAddress =
       await godwoker.getShortAddressByAllTypeEthAddress(deployerAddress);
+    deployerRecipientAddress = shortAddress.value;
     console.log("Deployer godwoken address:", deployerRecipientAddress);
   }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -640,13 +640,13 @@
     proper-lockfile "^4.1.1"
     solidity-ast "^0.4.15"
 
-"@polyjuice-provider/base@0.0.1-rc7":
-  version "0.0.1-rc7"
-  resolved "https://registry.yarnpkg.com/@polyjuice-provider/base/-/base-0.0.1-rc7.tgz#5df16cccc178f049192139758ecd7852e4529480"
-  integrity sha512-wFwDBf2xpDBySAjBKI0A1ugfJ8398MW+LiLPQiJoY1Ca1e85+I6OMYCjQGGGYB2gbALWKwAcplin7RVbGiajPA==
+"@polyjuice-provider/base@0.0.1-rc10":
+  version "0.0.1-rc10"
+  resolved "https://registry.yarnpkg.com/@polyjuice-provider/base/-/base-0.0.1-rc10.tgz#23e8c74993eaaaa18a391a103e18f1aedcc369f4"
+  integrity sha512-2cGKXh2ST57qMlthL8tKVv5/JM+RtrJnIjifD1Sx7zWpKuFa+m6MWjwK+LUNWJzO3/6NKjhotIEMOqr3jI++HQ==
   dependencies:
     "@ckb-lumos/base" "^0.16.0"
-    "@polyjuice-provider/godwoken" "^0.0.1-rc7"
+    "@polyjuice-provider/godwoken" "^0.0.1-rc10"
     buffer "^6.0.3"
     encoding "^0.1.13"
     eth-sig-util "^3.0.1"
@@ -655,20 +655,20 @@
     web3 "^1.3.4"
     xhr2-cookies "^1.1.0"
 
-"@polyjuice-provider/ethers@^0.0.1-rc7":
-  version "0.0.1-rc7"
-  resolved "https://registry.yarnpkg.com/@polyjuice-provider/ethers/-/ethers-0.0.1-rc7.tgz#264191d3a1cfc304f6c1182b633c6f3350f7fbaa"
-  integrity sha512-h+3wvQPwoCYb/Ob6j9wfpo9rYhsogehzB3GN5wu5Ut0qc9oTVe5Qt3AOb8g7rdH5Z7nONIExplAi6lvKreLyBQ==
+"@polyjuice-provider/ethers@^0.0.1-rc10":
+  version "0.0.1-rc10"
+  resolved "https://registry.yarnpkg.com/@polyjuice-provider/ethers/-/ethers-0.0.1-rc10.tgz#9075676460e3d005abe86a621abd572556c69159"
+  integrity sha512-U7CJp35nXFtL44IyY6Te5lhP2JzAa0d6IIJfmuWU5QwtYLxlisN3okBAGe+aCMw/3cKFkpsKIVteG+sgH2hL+g==
   dependencies:
-    "@polyjuice-provider/base" "0.0.1-rc7"
+    "@polyjuice-provider/base" "0.0.1-rc10"
     buffer "^6.0.3"
     encoding "^0.1.13"
     ethers "^5.4.0"
 
-"@polyjuice-provider/godwoken@^0.0.1-rc7":
-  version "0.0.1-rc7"
-  resolved "https://registry.yarnpkg.com/@polyjuice-provider/godwoken/-/godwoken-0.0.1-rc7.tgz#1c7ff81d92061adbbd1da51721d1545d20e4a2a1"
-  integrity sha512-jBQ1Ivf1TbcX935bUh+QPWwCdueQEsEmLzU6gU3/luTVNwBHHrNElwMDtoqrTVi0akA9CRMWoNMKzSTjNnTNNw==
+"@polyjuice-provider/godwoken@^0.0.1-rc10":
+  version "0.0.1-rc10"
+  resolved "https://registry.yarnpkg.com/@polyjuice-provider/godwoken/-/godwoken-0.0.1-rc10.tgz#ca927aac16d80046440b278cdba7f08b85c5c832"
+  integrity sha512-8Em+jlKqaoDqFM3Ab+fax3dV6gZbMB0oAdsHgxyuiP0XmNBccZRA1PnHwgTzB1hcauqAz4J9IbO92tDY717Vfg==
   dependencies:
     "@ckb-lumos/base" "^0.16.0"
     ckb-js-toolkit "^0.9.3"


### PR DESCRIPTION
there are some web3 apis which might be deprecated in the future, so we suggest upgrade provider version to v0.0.1-rc10 or above as soon as possible.