### PR TITLE
fix: init godwoken accounts of signers first

### DIFF
--- a/scripts/multi-sign-wallet.ts
+++ b/scripts/multi-sign-wallet.ts
@@ -108,8 +108,12 @@ const txOverride = {
 };
 
 async function main() {
-  console.log("Deployer address:", deployerAddress);
+  // init godwoken accounts of signers first
+  await initGWKAccountIfNeeded(signerTwoAddress);
+  await initGWKAccountIfNeeded(signerOneAddress);
   await initGWKAccountIfNeeded(deployerAddress);
+
+  console.log("Deployer address:", deployerAddress);
 
   // explicitly get godwoken address for `populateTransaction` encoding
   let deployerRecipientAddress = deployerAddress;
@@ -205,7 +209,6 @@ async function main() {
     (await mintableToken.balanceOf(deployerRecipientAddress)).toString(),
   );
 
-  await initGWKAccountIfNeeded(signerTwoAddress);
   await transactionSubmitter.submitAndWait(
     `Mint 100 token using WalletSimple`,
     async () => {


### PR DESCRIPTION
Fix Error: unable to fetch script hash from short address: 0x65d1084524de5a180cc032d0f357a30caa3a4b67

> https://github.com/nervosnetwork/godwoken-tests/runs/3728699704?check_suite_focus=true#step:14:79